### PR TITLE
Warning in README about using unexpected external service

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ To use AgentCoder, you need to have an API key from OpenAI or other similar thir
 3. Add your API key in the `programmer_[humaneval/mbpp].py` and `test_designer_[humaneval/mbpp].py` files:
    ```python
    openai.api_key = 'YOUR_API_KEY'
+   # openai.api_base = "https:// ... aiohub.org endpoint ..." # remove this line if you don't intend to trust and use this specific service
    ```
 
 ## Usage


### PR DESCRIPTION
Beware about what service the API key and prompts are shared with by default: https://github.com/huangd1999/AgentCoder/blame/d87f40e7723a8803cce07ab07aedcb924e44b8fa/src/programmer_humaneval.py#L12
```
import ...
openai.api_base = "https://api.aiohub.org/v1"
```